### PR TITLE
Introduces the configuration for lib_jobs

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -70,5 +70,11 @@
     "auto_merge": false,
     "repository": "pulibrary/discoveryutils",
     "environments": ["staging", "production"]
+  },
+  "lib_jobs": {
+    "provider": "capistrano",
+    "auto_merge": false,
+    "repository": "pulibrary/lib_jobs",
+    "environments": ["staging", "production"]
   }
 }


### PR DESCRIPTION
Currently redeploying into the `staging` and `production` environments requires that Capistrano be used in a terminal.