### PR TITLE
Add alma-production as a bibdata deploy environment

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -9,7 +9,7 @@
     "provider": "capistrano",
     "auto_merge": false,
     "repository": "pulibrary/orangelight",
-    "environments": ["staging", "production", "alma_qa", "qa"]
+    "environments": ["staging", "production", "alma-qa", "qa"]
   },
   "dpul": {
     "provider": "capistrano",
@@ -33,7 +33,7 @@
     "provider": "capistrano",
     "auto_merge": false,
     "repository": "pulibrary/bibdata",
-    "environments": ["staging", "alma-staging", "production"]
+    "environments": ["staging", "alma-staging", "production", "alma-production"]
   },
   "lae": {
     "provider": "capistrano",


### PR DESCRIPTION
Also change orangelight `alma_qa` to `alma-qa` for consistency with
other commends
