### PR TITLE
Allow "rolling" library deploy for the main library site

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -93,7 +93,7 @@
     "provider": "capistrano",
     "auto_merge": false,
     "repository": "pulibrary/pul_library_drupal",
-    "environments": ["staging", "production"]
+    "environments": ["staging", "production", "production_rolla", "production_rollb"]
   },
   "mudd-dbs": {
     "provider": "capistrano",


### PR DESCRIPTION
This is accomplished by only deploying to one server and then the other two
refs https://github.com/pulibrary/pul_library_drupal/pull/1820