### PR TITLE
rename repec to repecwp

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -119,7 +119,7 @@
     "repository": "pulibrary/special_collections",
     "environments": ["staging", "production"]
   },
-  "repec": {
+  "repecwp": {
     "provider": "capistrano",
     "auto_merge": false,
     "repository": "pulibrary/repecwp",


### PR DESCRIPTION
I assumed the wp was word press and left it off, but it is really working paper
That means to match, the repo should be in the name of the app being deployed